### PR TITLE
Fixed memory leak.

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -24,6 +24,7 @@ output(struct ansilove_ctx *ctx, struct ansilove_options *options,
 
 	if (!options->scale_factor && !options->dos) {
 		ctx->png.buffer = gdImagePngPtr(im_Source, &ctx->png.length);
+		gdImageDestroy(im_Source);
 	} else if (options->dos) {
 		gdImagePtr im_DOS;
 


### PR DESCRIPTION
I was seeing ~200MB of memory leaking when generating PNGs from ~70 ANSi files (.ans, .xb). I did some poking around the libansilove source and this was my best guess at the fix. I don't have any experience with the codebase, so there may be a better way to fix this leak. In my limited testing this fixes the leak without any apparent side-effects.