### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 arch:
   - amd64
   - arm64
+  - ppc64le
 
 matrix:
   include:
@@ -8,6 +9,8 @@ matrix:
      arch: amd64
    - os: linux
      arch: arm64
+   - os: linux
+     arch: ppc64le     
 
 language: c
 


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3