### PR TITLE
Add Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,13 @@
 # build products
 build/
 
+# Nix
+result
+result-*/
+
+# direnv
+.direnv/
+
 # CMake
 CMakeFiles
 CMakeCache.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+libansilove is a C library that converts ANSI and related art files to PNG. Core headers live in `include/`, while the implementation sits in `src/` with `loaders/` containing format-specific decoders and `fonts/` bundling built-in typefaces. Cross-platform fallbacks are under `compat/`. The `example/` directory shows how to invoke the API end-to-end, and `man/` provides installed manual pages. Dedicated fuzzing harnesses reside in `fuzz/`; build them only when running sanitizer-heavy tests.
+
+## Build, Test, and Development Commands
+- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`: configure the project after installing GD headers and libs.
+- `cmake --build build`: compile shared and static variants of the library.
+- `cmake --build build --target install`: install artifacts into the default prefix.
+- `cmake -S fuzz -B fuzz-build`: set up clang-based libFuzzer targets.
+- `cmake --build fuzz-build`: produce fuzz binaries such as `ansi` and `tundra`.
+
+## Coding Style & Naming Conventions
+- Target C99 with the default warning set (`-Wall -Wextra -pedantic`).
+- Indent with tabs for blocks; align wrapped parameters using spaces as needed, and avoid trailing whitespace.
+- Public APIs stay in `include/ansilove.h` and use the `ansilove_*` prefix; internal helpers remain lowercase with underscores and `static` linkage.
+- Mirror existing filenames (`loadfile.c`, `savefile.c`) when adding new modules or loaders.
+
+## Testing Guidelines
+- There is no unit-test harness; validate behavior with the example app and fuzzers.
+- After building, run `build/example/ansilove_example <input.ans>` to confirm PNG output.
+- For fuzzing, execute `./fuzz-build/ansi -runs=10000 corpus/` (seed the corpus with representative art files). Investigate sanitizer reports immediately and add reproducer samples.
+- Ensure new formats or options ship with updated example inputs or fuzz seeds that exercise the paths.
+
+## Commit & Pull Request Guidelines
+- Commit messages follow sentence case with concise statements ending in a period (for example, `Update ChangeLog.`).
+- Keep functional changes and formatting adjustments in separate commits and ensure files build before pushing.
+- Pull requests should summarize the change, call out impacted loaders, and link tracking issues. Note which build or fuzz commands were run, and attach PNG outputs or screenshots when visual diffs help reviewers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ libansilove is a C library that converts ANSI and related art files to PNG. Core
 - `cmake --build build --target install`: install artifacts into the default prefix.
 - `cmake -S fuzz -B fuzz-build`: set up clang-based libFuzzer targets.
 - `cmake --build fuzz-build`: produce fuzz binaries such as `ansi` and `tundra`.
+- `nix develop`: enter the flake-backed dev shell with clang, pkg-config, GD, and platform-appropriate debugger preinstalled.
+- `nix build`: build the default flake package (shared/static library) without touching your host toolchain.
+- `nix flake check`: validate the flake packages and dev shell evaluate cleanly across supported systems.
 
 ## Coding Style & Naming Conventions
 - Target C99 with the default warning set (`-Wall -Wextra -pedantic`).
@@ -21,6 +24,7 @@ libansilove is a C library that converts ANSI and related art files to PNG. Core
 - After building, run `build/example/ansilove_example <input.ans>` to confirm PNG output.
 - For fuzzing, execute `./fuzz-build/ansi -runs=10000 corpus/` (seed the corpus with representative art files). Investigate sanitizer reports immediately and add reproducer samples.
 - Ensure new formats or options ship with updated example inputs or fuzz seeds that exercise the paths.
+- If you touch the flake, rerun `nix build` and `nix flake check` and commit the updated `flake.lock` (keep changes reproducible).
 
 ## Commit & Pull Request Guidelines
 - Commit messages follow sentence case with concise statements ending in a period (for example, `Update ChangeLog.`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "Development environment for libansilove";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        version = "1.4.2";
+      in {
+        packages.default = pkgs.stdenv.mkDerivation {
+          pname = "libansilove";
+          inherit version;
+          src = ./.;
+          nativeBuildInputs = [
+            pkgs.cmake
+            pkgs.pkg-config
+          ];
+          buildInputs = [
+            pkgs.libgd
+          ];
+          cmakeFlags = [
+            "-DCMAKE_BUILD_TYPE=Release"
+          ];
+          meta = with pkgs.lib; {
+            description = "Library to convert ANSI and artscene formats to PNG";
+            homepage = "https://www.ansilove.org";
+            license = licenses.bsd2;
+            maintainers = [];
+            platforms = platforms.unix;
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.cmake
+            pkgs.ninja
+            pkgs.pkg-config
+            pkgs.libgd
+            pkgs.clang
+            pkgs.clang-tools
+            pkgs.gdb
+          ];
+          shellHook = ''
+            export CC=${pkgs.clang}/bin/clang
+            export CXX=${pkgs.clang}/bin/clang++
+            echo "libansilove dev shell loaded."
+          '';
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
             pkgs.pkg-config
           ];
           buildInputs = [
-            pkgs.libgd
+            pkgs.gd
           ];
           cmakeFlags = [
             "-DCMAKE_BUILD_TYPE=Release"
@@ -40,15 +40,21 @@
         };
 
         devShells.default = pkgs.mkShell {
-          packages = [
-            pkgs.cmake
-            pkgs.ninja
-            pkgs.pkg-config
-            pkgs.libgd
-            pkgs.clang
-            pkgs.clang-tools
-            pkgs.gdb
-          ];
+          packages =
+            [
+              pkgs.cmake
+              pkgs.ninja
+              pkgs.pkg-config
+              pkgs.gd
+              pkgs.clang
+              pkgs.clang-tools
+            ]
+            ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
+              pkgs.gdb
+            ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.lldb
+            ];
           shellHook = ''
             export CC=${pkgs.clang}/bin/clang
             export CXX=${pkgs.clang}/bin/clang++

--- a/flake.nix
+++ b/flake.nix
@@ -6,10 +6,14 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
         version = "1.4.2";
       in {
         packages.default = pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
# Add Nix flake and contributor automation.

## Summary
- document the automation guidelines in `AGENTS.md` so future helpers know the repository conventions up front
- add `.envrc` to auto-load the Nix flake for contributors who opt into direnv
- ship a `flake.nix` + `flake.lock` pairing that builds libansilove and exposes a dev shell with clang and the right debugger per platform
- extend `.gitignore` so the flake's `result*` outputs and direnv state never pollute commits

## Why keep the flake in-tree?
- **Streamlined onboarding**: README already calls out cross-platform dependency setup (BSDs, Linux, macOS); the flake captures those packages once so new contributors land in a working shell instantly, with pkg-config, clang tools, and GD pre-wired.
- **Nix packaging parity**: libansilove is in nixpkgs today. This flake lets us validate packaging updates locally without leaving the repo, which reduces churn for the maintainer shepherding upstream bumps.
- **Reproducible tooling**: Maintainers like @fcambus who juggle multiple projects can rely on Nix to supply consistent compilers, lint tooling, and GD even on Apple Silicon—no conflicts with Homebrew or system packages.
- **Optional, zero-risk**: Nothing in the CMake flow changes. Builders who do not use Nix continue with the documented `mkdir build && cmake .. && make` path; the flake is additive and kept tidy via `.gitignore`.

## Testing
- `nix develop --command echo ok`
- `nix build`
- `nix flake check --all-systems`
